### PR TITLE
Add many to many mapping

### DIFF
--- a/src/Modules/SimplCommerce.Module.Core/Data/SimplDbContext.cs
+++ b/src/Modules/SimplCommerce.Module.Core/Data/SimplDbContext.cs
@@ -33,6 +33,8 @@ namespace SimplCommerce.Module.Core.Data
             base.OnModelCreating(modelBuilder);
 
             RegisterCustomMappings(modelBuilder, typeToRegisters);
+
+            ManyToManyMapping(modelBuilder);
         }
 
         private static void RegisterConvention(ModelBuilder modelBuilder)
@@ -68,6 +70,22 @@ namespace SimplCommerce.Module.Core.Data
                     builder.Build(modelBuilder);
                 }
             }
+        }
+
+        private static void ManyToManyMapping(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<UserAddress>()
+                .HasKey(ua => new { ua.UserId, ua.AddressId });
+
+            modelBuilder.Entity<UserAddress>()
+                .HasOne(ua => ua.User)
+                .WithMany(u => u.UserAddresses)
+                .HasForeignKey(ua => ua.UserId);
+
+            modelBuilder.Entity<UserAddress>()
+                .HasOne(ua => ua.Address)
+                .WithMany(a => a.UserAddresses)
+                .HasForeignKey(ua => ua.AddressId);
         }
     }
 }


### PR DESCRIPTION
## Issue
When "Update-Database" is entered in Package Manager Console, it returns an error saying

> Unable to determine the relationship represented by navigation property 'User.UserAddresses' of type 'IList<UserAddress>'. Either manually configure the relationship, or ignore this property using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.

## Fix
Add many to many mapping at OnModelCreating.
