### PR TITLE
#494 Added default value false for Culture.IsDefault property

### DIFF
--- a/src/Modules/SimplCommerce.Module.Localization/Data/LocalizationCustomModelBuilder.cs
+++ b/src/Modules/SimplCommerce.Module.Localization/Data/LocalizationCustomModelBuilder.cs
@@ -11,6 +11,7 @@ namespace SimplCommerce.Module.Localization.Data
             modelBuilder.Entity<Culture>().HasData(
                new Culture("en-US") { Name = "English (US)", IsDefault = true }
             );
+            modelBuilder.Entity<Culture>().Property(x => x.IsDefault).HasDefaultValue(false);
         }
     }
 }


### PR DESCRIPTION
Fixed issue where Constraint violations happen while trying to insert a culture to db without IsDefault property set. 

This probably isnt a problem when using mysql since mysql ignores these kind of errors and just uses a default value that it thinks fits. However Postgresql throws an error when constraint violations like this one happens

Issue #494 