### PR TITLE
Issue-630 Display duplicate tree of categories in product filters

### DIFF
--- a/src/Modules/SimplCommerce.Module.Search/Areas/Search/Controllers/SearchController.cs
+++ b/src/Modules/SimplCommerce.Module.Search/Areas/Search/Controllers/SearchController.cs
@@ -63,7 +63,7 @@ namespace SimplCommerce.Module.Search.Areas.Search.Controllers
 
             var query = _productRepository.Query().Where(x => x.Name.Contains(searchOption.Query) && x.IsPublished && x.IsVisibleIndividually);
 
-            if (query.Count() == 0)
+            if (!query.Any())
             {
                 model.TotalProduct = 0;
                 return View(model);

--- a/src/Modules/SimplCommerce.Module.Search/Areas/Search/Views/Search/Index.cshtml
+++ b/src/Modules/SimplCommerce.Module.Search/Areas/Search/Views/Search/Index.cshtml
@@ -35,7 +35,7 @@
                                             <small>(@category.Count)</small>
                                         </label>
                                         @{
-                                            var children = Model.FilterOption.Categories.Where(x => x.ParentId == category.Id).ToList();
+                                            var children = Model.FilterOption.Categories.Where(x => x.ParentId == category.Id);
                                         }
                                         @if (children.Any())
                                         {

--- a/src/Modules/SimplCommerce.Module.Search/Areas/Search/Views/Search/Index.cshtml
+++ b/src/Modules/SimplCommerce.Module.Search/Areas/Search/Views/Search/Index.cshtml
@@ -26,7 +26,7 @@
                     <div id="collapse-category" class="collapse show" aria-labelledby="cardHeaderCategory" data-parent="#accordion-category">
                         <div class="card-body">
                             <ul class="list-unstyled checkbox-list">
-                                @foreach (var category in Model.FilterOption.Categories)
+                                @foreach (var category in Model.FilterOption.Categories.Where(x => x.ParentId == null))
                                 {
                                     <li>
                                         <label class="checkbox">
@@ -35,7 +35,7 @@
                                             <small>(@category.Count)</small>
                                         </label>
                                         @{
-                                            var children = Model.FilterOption.Categories.Where(x => x.ParentId == category.Id);
+                                            var children = Model.FilterOption.Categories.Where(x => x.ParentId == category.Id).ToList();
                                         }
                                         @if (children.Any())
                                         {


### PR DESCRIPTION
This pull request is to fix an issue displaying duplicate sub-categories in product filters.