### PR TITLE
Azure Pipelines: add macOS and Windows builds and run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 [![Join the chat at https://gitter.im/simplcommerce/SimplCommerce](https://badges.gitter.im/simplcommerce/SimplCommerce.svg)](https://gitter.im/simplcommerce/SimplCommerce?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Build Status
-| Build server| Platform       | Status      |
-|-------------|----------------|-------------|
-| AppVeyor    | Windows        |[![Build status](https://ci.appveyor.com/api/projects/status/cq61prgs6ta8e9hi/branch/master?svg=true)](https://ci.appveyor.com/project/thiennn/simplcommerce/branch/master) |
-|Travis       | Linux / MacOS  |[![Build Status](https://travis-ci.org/simplcommerce/SimplCommerce.svg?branch=master)](https://travis-ci.org/simplcommerce/SimplCommerce) |
+| Build server    | Platform       | Status      |
+|-----------------|----------------|-------------|
+| AppVeyor        | Windows        |[![Build status](https://ci.appveyor.com/api/projects/status/cq61prgs6ta8e9hi/branch/master?svg=true)](https://ci.appveyor.com/project/thiennn/simplcommerce/branch/master) |
+| Azure Pipelines | All            |[![Build Status](https://simplcommerce.visualstudio.com/simplcommerce/_apis/build/status/simplcommerce.SimplCommerce?branchName=master)](https://simplcommerce.visualstudio.com/simplcommerce/_build/latest?definitionId=1&branchName=master)
+|Travis           | Linux / MacOS  |[![Build Status](https://travis-ci.org/simplcommerce/SimplCommerce.svg?branch=master)](https://travis-ci.org/simplcommerce/SimplCommerce) |
 
 ## Online demo (Azure Website)
 - Store front: http://demo.simplcommerce.com

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,12 +3,52 @@
 # Add steps that run tests, create a NuGet package, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
-pool:
-  vmImage: 'Ubuntu 16.04'
+trigger:
+- master
 
-variables:
-  buildConfiguration: 'Release'
+jobs:
+- job: Linux
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - script: |
+      dotnet restore
+      dotnet build ./SimplCommerce.sln
+    displayName: 'dotnet build'
+  - script: ./run-tests.sh
+    displayName: 'run tests'
 
-steps:
-- script: dotnet build --configuration $(buildConfiguration)
-  displayName: 'dotnet build $(buildConfiguration)'
+- job: macOS
+  pool:
+    vmImage: 'macOS-10.13'
+  steps:
+  - script: |
+      dotnet restore
+      dotnet build ./SimplCommerce.sln
+    displayName: 'dotnet build'
+  - script: ./run-tests.sh
+    displayName: 'run tests'
+
+- job: Windows
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - script: |
+      dotnet restore
+      dotnet build ./SimplCommerce.sln
+    displayName: 'dotnet build'
+  - task: PowerShell@2
+    inputs:
+      filePath: .\run-tests.ps1
+    displayName: 'run tests'
+
+- job: LinuxRelease
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  variables:
+    buildConfiguration: 'Release'
+  steps:
+  - script: dotnet build --configuration $(buildConfiguration)
+    displayName: 'dotnet build $(buildConfiguration)'
+  - script: ./run-tests.sh
+    displayName: 'run tests'    


### PR DESCRIPTION
This PR:
- Adds macOS and Windows jobs
- Runs the tests on all three platforms
- Sets the build trigger to be changes to master and PRs only

I also added a build badge for Azure Pipelines to the README. It is currently scoped to `master`.