### PR TITLE
Azure Blob Storage: Create container before setting permissions

### DIFF
--- a/src/Modules/SimplCommerce.Module.StorageAzureBlob/AzureBlobStorageService.cs
+++ b/src/Modules/SimplCommerce.Module.StorageAzureBlob/AzureBlobStorageService.cs
@@ -46,8 +46,8 @@ namespace SimplCommerce.Module.StorageAzureBlob
 
         public async Task SaveMediaAsync(Stream mediaBinaryStream, string fileName, string mimeType = null)
         {
-            await _blobContainer.SetPermissionsAsync(new BlobContainerPermissions { PublicAccess = BlobContainerPublicAccessType.Container });
             await _blobContainer.CreateIfNotExistsAsync();
+            await _blobContainer.SetPermissionsAsync(new BlobContainerPermissions { PublicAccess = BlobContainerPublicAccessType.Container });
 
             var blockBlob = _blobContainer.GetBlockBlobReference(fileName);
             await blockBlob.UploadFromStreamAsync(mediaBinaryStream);


### PR DESCRIPTION
If container doesn't exist, we never reached the "CreateIfNotExists" line due to changing permissions first.