### PR TITLE
Enable Central Package Management for NuGet Dependencies

### DIFF
--- a/Directory.Packages.Props
+++ b/Directory.Packages.Props
@@ -1,0 +1,53 @@
+﻿<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.10" />
+        <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.10" />
+        <PackageVersion Include="DinkToPdf" Version="1.0.8" />
+        <PackageVersion Include="Sendgrid" Version="9.28.1" />
+        <PackageVersion Include="MailKit" Version="4.2.0" />
+        <PackageVersion Include="Braintree" Version="5.20.0" />
+        <PackageVersion Include="Stripe.net" Version="22.8.0" />
+        <PackageVersion Include="AWSSDK.S3" Version="3.7.205.15" />
+        <PackageVersion Include="Azure.Storage.Blobs" Version="12.18.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.10" />
+        <PackageVersion Include="Humanizer" Version="2.14.1" />
+        <PackageVersion Include="MediatR" Version="12.1.1" />
+        <PackageVersion Include="cloudscribe.Web.Pagination" Version="6.0.0" />
+        <PackageVersion Include="ncrontab" Version="3.3.3" />
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageVersion Include="IdentityServer4.AspNetIdentity" Version="4.1.2" />
+        <PackageVersion Include="BuildBundlerMinifier" Version="3.2.449" />
+        <PackageVersion Include="Microsoft.AspNetCore.Antiforgery" Version="2.2.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0"/>            
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+        <PackageVersion Include="Serilog.Extensions.Logging" Version="7.0.0" />
+        <PackageVersion Include="Serilog.Settings.Configuration" Version="7.0.1" />
+        <PackageVersion Include="Serilog.Sinks.RollingFile" Version="3.3.1-dev-00771" />           
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageVersion Include="xunit" Version="2.5.0" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0"/>
+        <PackageVersion Include="coverlet.msbuild" Version="6.0.0"/>     
+        <PackageVersion Include="Moq" Version="4.20.69" />        
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />       
+        <PackageVersion Include="MockQueryable.Moq" Version="7.0.1" />      
+        <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+      
+           
+        
+       
+       
+            
+        
+    </ItemGroup>
+</Project>

--- a/SimplCommerce.sln
+++ b/SimplCommerce.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0FA25035-EF21-45F1-BEB4-C57BCF5F9A83}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Packages.Props = Directory.Packages.Props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Modules", "Modules", "{7EFA2FA7-32DD-4047-B021-50E77A83D714}"
@@ -137,6 +138,7 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimplCommerce.Module.Checkouts", "src\Modules\SimplCommerce.Module.Checkouts\SimplCommerce.Module.Checkouts.csproj", "{4473538D-2BFA-4C53-B642-0D0DC4F16863}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimplCommerce.Module.ProductComparison.Tests", "test\SimplCommerce.Module.ProductComparison.Tests\SimplCommerce.Module.ProductComparison.Tests.csproj", "{EEC02E89-E89A-4871-8C3E-4BABA1E56CA7}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimplCommerce.Module.ShippingFree.Tests", "test\SimplCommerce.Module.ShippingFree.Tests\SimplCommerce.Module.ShippingFree.Tests.csproj", "{16BB6B44-3300-4C22-A37B-D9CD7A4EA300}"
 EndProject
 Global

--- a/src/Modules/SimplCommerce.Module.Core/SimplCommerce.Module.Core.csproj
+++ b/src/Modules/SimplCommerce.Module.Core/SimplCommerce.Module.Core.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.10" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"  />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"  />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Modules/SimplCommerce.Module.DinkToPdf/SimplCommerce.Module.DinkToPdf.csproj
+++ b/src/Modules/SimplCommerce.Module.DinkToPdf/SimplCommerce.Module.DinkToPdf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <ItemGroup>
-    <PackageReference Include="DinkToPdf" Version="1.0.8" />
+    <PackageReference Include="DinkToPdf" />
     <ProjectReference Include="..\..\SimplCommerce.Infrastructure\SimplCommerce.Infrastructure.csproj" />
     <ProjectReference Include="..\SimplCommerce.Module.Core\SimplCommerce.Module.Core.csproj" />
   </ItemGroup>

--- a/src/Modules/SimplCommerce.Module.EmailSenderSendgrid/SimplCommerce.Module.EmailSenderSendgrid.csproj
+++ b/src/Modules/SimplCommerce.Module.EmailSenderSendgrid/SimplCommerce.Module.EmailSenderSendgrid.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sendgrid" Version="9.28.1" />
+    <PackageReference Include="Sendgrid" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Modules/SimplCommerce.Module.EmailSenderSmtp/SimplCommerce.Module.EmailSenderSmtp.csproj
+++ b/src/Modules/SimplCommerce.Module.EmailSenderSmtp/SimplCommerce.Module.EmailSenderSmtp.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SimplCommerce.Module.Core\SimplCommerce.Module.Core.csproj" />
-    <PackageReference Include="MailKit" Version="4.2.0" />
+    <PackageReference Include="MailKit" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/SimplCommerce.Module.PaymentBraintree/SimplCommerce.Module.PaymentBraintree.csproj
+++ b/src/Modules/SimplCommerce.Module.PaymentBraintree/SimplCommerce.Module.PaymentBraintree.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Braintree" Version="5.20.0" />
+    <PackageReference Include="Braintree" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SimplCommerce.Infrastructure\SimplCommerce.Infrastructure.csproj" />

--- a/src/Modules/SimplCommerce.Module.PaymentStripe/SimplCommerce.Module.PaymentStripe.csproj
+++ b/src/Modules/SimplCommerce.Module.PaymentStripe/SimplCommerce.Module.PaymentStripe.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\SimplCommerce.Module.Core\SimplCommerce.Module.Core.csproj" />
     <ProjectReference Include="..\SimplCommerce.Module.Orders\SimplCommerce.Module.Orders.csproj" />
     <ProjectReference Include="..\SimplCommerce.Module.Payments\SimplCommerce.Module.Payments.csproj" />
-    <PackageReference Include="Stripe.net" Version="22.8.0" />
+    <PackageReference Include="Stripe.net" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/SimplCommerce.Module.StorageAmazonS3/SimplCommerce.Module.StorageAmazonS3.csproj
+++ b/src/Modules/SimplCommerce.Module.StorageAmazonS3/SimplCommerce.Module.StorageAmazonS3.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.205.15" />
+    <PackageReference Include="AWSSDK.S3"  />
     <ProjectReference Include="..\..\SimplCommerce.Infrastructure\SimplCommerce.Infrastructure.csproj" />
     <ProjectReference Include="..\SimplCommerce.Module.Core\SimplCommerce.Module.Core.csproj" />
   </ItemGroup>

--- a/src/Modules/SimplCommerce.Module.StorageAzureBlob/SimplCommerce.Module.StorageAzureBlob.csproj
+++ b/src/Modules/SimplCommerce.Module.StorageAzureBlob/SimplCommerce.Module.StorageAzureBlob.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.18.0" />
+    <PackageReference Include="Azure.Storage.Blobs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SimplCommerce.Infrastructure/SimplCommerce.Infrastructure.csproj
+++ b/src/SimplCommerce.Infrastructure/SimplCommerce.Infrastructure.csproj
@@ -9,13 +9,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.10" />
-    <PackageReference Include="Humanizer" Version="2.14.1" />
-    <PackageReference Include="MediatR" Version="12.1.1" />
-    <PackageReference Include="cloudscribe.Web.Pagination" Version="6.0.0" />
-    <PackageReference Include="ncrontab" Version="3.3.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"  />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational"  />
+    <PackageReference Include="Humanizer"  />
+    <PackageReference Include="MediatR"  />
+    <PackageReference Include="cloudscribe.Web.Pagination"  />
+    <PackageReference Include="ncrontab"  />
+    <PackageReference Include="Newtonsoft.Json"  />
   </ItemGroup>
 
 </Project>

--- a/src/SimplCommerce.WebHost/SimplCommerce.WebHost.csproj
+++ b/src/SimplCommerce.WebHost/SimplCommerce.WebHost.csproj
@@ -55,23 +55,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4.AspNetIdentity" Version="4.1.2" />
-    <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+    <PackageReference Include="IdentityServer4.AspNetIdentity"  />
+    <PackageReference Include="BuildBundlerMinifier"  />
+    <PackageReference Include="Microsoft.AspNetCore.Antiforgery"  />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook"  />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google"  />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"  />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson"  />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
-    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.1-dev-00771" />
-    <PackageReference Include="Humanizer" Version="2.14.1" />
-    <PackageReference Include="MediatR" Version="12.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Serilog.Extensions.Logging"  />
+    <PackageReference Include="Serilog.Settings.Configuration"  />
+    <PackageReference Include="Serilog.Sinks.RollingFile"  />
+    <PackageReference Include="Humanizer"  />
+    <PackageReference Include="MediatR"  />
+    <PackageReference Include="Swashbuckle.AspNetCore"  />
   </ItemGroup>
 </Project>

--- a/test/SimplCommerce.Infrastructure.Tests/SimplCommerce.Infrastructure.Tests.csproj
+++ b/test/SimplCommerce.Infrastructure.Tests/SimplCommerce.Infrastructure.Tests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="xunit"  />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/SimplCommerce.Module.Cms.Tests/SimplCommerce.Module.Cms.Tests.csproj
+++ b/test/SimplCommerce.Module.Cms.Tests/SimplCommerce.Module.Cms.Tests.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="Moq"  />
+    <PackageReference Include="xunit"  />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+	<PackageReference Include="coverlet.msbuild" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/SimplCommerce.Module.Core.Tests/SimplCommerce.Module.Core.Tests.csproj
+++ b/test/SimplCommerce.Module.Core.Tests/SimplCommerce.Module.Core.Tests.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="Moq"  />
+    <PackageReference Include="xunit"  />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+	<PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/SimplCommerce.Module.Inventory.Tests/SimplCommerce.Module.Inventory.Tests.csproj
+++ b/test/SimplCommerce.Module.Inventory.Tests/SimplCommerce.Module.Inventory.Tests.csproj
@@ -6,17 +6,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="MockQueryable.Moq" Version="7.0.1" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore"  />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="MockQueryable.Moq"  />
+    <PackageReference Include="Moq"  />
+    <PackageReference Include="System.Linq.Async"  />
+    <PackageReference Include="xunit"  />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+	<PackageReference Include="coverlet.msbuild" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/SimplCommerce.Module.Pricing.Tests/SimplCommerce.Module.Pricing.Tests.csproj
+++ b/test/SimplCommerce.Module.Pricing.Tests/SimplCommerce.Module.Pricing.Tests.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="Moq"  />
+    <PackageReference Include="xunit"  />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+	<PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/SimplCommerce.Module.ProductComparison.Tests/SimplCommerce.Module.ProductComparison.Tests.csproj
+++ b/test/SimplCommerce.Module.ProductComparison.Tests/SimplCommerce.Module.ProductComparison.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -7,14 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-        <PackageReference Include="Moq" Version="4.20.69" />
-        <PackageReference Include="xunit" Version="2.5.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+        <PackageReference Include="Moq"  />
+        <PackageReference Include="xunit"  />
+        <PackageReference Include="xunit.runner.visualstudio" >
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" >
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/test/SimplCommerce.Module.ShippingFree.Tests/SimplCommerce.Module.ShippingFree.Tests.csproj
+++ b/test/SimplCommerce.Module.ShippingFree.Tests/SimplCommerce.Module.ShippingFree.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="Moq"  />
+    <PackageReference Include="xunit"  />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This PR enables Central Package Management (CPM) for NuGet dependencies in the solution. The following changes were made:

Added Directory.Packages.Props to manage package versions centrally.
Removed individual package version specifications from project files (.csproj).
Ensured compatibility across all projects in the solution.
**Why this is needed:**
Simplifies package version management across multiple projects.
Ensures consistency and avoids version conflicts.
Makes dependency updates easier by modifying a single file.
**Testing:**
Verified that the solution builds successfully.
Checked that all projects reference the correct package versions.