### PR TITLE
Docs add local db connection string fallback for developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,18 @@ Continuous deployment: https://ci.simplcommerce.com
 
 #### Steps to run
 
-- **Update the connection string**: Open `appsettings.json` in `src/SimplCommerce.WebHost`.
-  - If you have **SQL Server** installed:
-    `"DefaultConnection": "Server=localhost;Database=SimplCommerce;Trusted_Connection=True;TrustServerCertificate=true"`
-  - If you **do not have SQL Server**, you can use **Visual Studio LocalDB**:
+- Update the connection string: Open `appsettings.json` in `src/SimplCommerce.WebHost`. 
+  - The default is configured for a local SQL Server. 
+    ```json
+    {
+    `"DefaultConnection": "Server=.;Database=SimplCommerce;Trusted_Connection=True;TrustServerCertificate=true"`
+    }
+  - If you are using Visual Studio LocalDB, change it to:
+    ```json
+    {
     `"DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=SimplCommerce;Trusted_Connection=True;TrustServerCertificate=true;MultipleActiveResultSets=true"`
+    }
+- Ensure you have a database named `SimplCommerce` created in your SQL instance, or change the `Database` name in the connection string to match your environment. 
 - Build the whole solution.
 - In Solution Explorer, make sure that SimplCommerce.WebHost is selected as the Startup Project
 - Open the Package Manager Console Window and make sure that SimplCommerce.WebHost is selected as the Default project. Then type "Update-Database" then press "Enter". This action will create the database schema.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ Continuous deployment: https://ci.simplcommerce.com
 
 #### Steps to run
 
-- Update the connection string in appsettings.json in SimplCommerce.WebHost
+- **Update the connection string**: Open `appsettings.json` in `src/SimplCommerce.WebHost`.
+  - If you have **SQL Server** installed:
+    `"DefaultConnection": "Server=localhost;Database=SimplCommerce;Trusted_Connection=True;TrustServerCertificate=true"`
+  - If you **do not have SQL Server**, you can use **Visual Studio LocalDB**:
+    `"DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=SimplCommerce;Trusted_Connection=True;TrustServerCertificate=true;MultipleActiveResultSets=true"`
 - Build the whole solution.
 - In Solution Explorer, make sure that SimplCommerce.WebHost is selected as the Startup Project
 - Open the Package Manager Console Window and make sure that SimplCommerce.WebHost is selected as the Default project. Then type "Update-Database" then press "Enter". This action will create the database schema.


### PR DESCRIPTION
Thank you for the feedback. I've updated the README to clarify the default Server=. usage, added the LocalDB alternative, and included a note about ensuring the SimplCommerce database exists. Hopefully, this makes the setup process much clearer for new users!
